### PR TITLE
feat: add InsertEnter autcmd for signature help

### DIFF
--- a/lua/autocomplete/signature.lua
+++ b/lua/autocomplete/signature.lua
@@ -93,7 +93,7 @@ function M.setup(config)
     state.entry = util.entry()
     local group = vim.api.nvim_create_augroup('LspSignatureHelp', {})
 
-    vim.api.nvim_create_autocmd('CursorMovedI', {
+    vim.api.nvim_create_autocmd({ 'CursorMovedI', 'InsertEnter' }, {
         desc = 'Auto show LSP signature help',
         group = group,
         callback = cursor_moved,


### PR DESCRIPTION
Often, I find myself needing to display the signature help without typing anything. So, here's a small modification to enhance the signature help feature.